### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+To report a security issue, please disclose it at [security advisory](https://github.com/KhronosGroup/glslang/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Security Policy
 
-To report a security issue, please disclose it at [security advisory](https://github.com/KhronosGroup/glslang/security/advisories/new).
+To report a security issue, please disclose it at [security advisory](https://github.com/KhronosGroup/Vulkan-Headers/security/advisories/new).
 
 This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Closes #430

I've created the SECURITY.md file considering the [Private vulnerability reporting (Beta)](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).

It must be [activated for the repository](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository):

1. Open the repo's settings
2. Click on [Code security & analysis](https://github.com/KhronosGroup/SPIRV-Tools/settings/security_analysis)
3. Click "Enable" for "Private vulnerability reporting (Beta)"

If you do not want to enable the vulnerability report feature, you can also receive the report by email. Please let me know the email address you would like to use, and I will make the necessary changes.

In addition, please feel free to edit or suggest any changes to this document. The goal is to ensure that the document accurately reflects the team's ability to handle vulnerabilities.